### PR TITLE
Agregar funcionalidad de conversión a PEM

### DIFF
--- a/src/components/CertificateValidator.css
+++ b/src/components/CertificateValidator.css
@@ -210,6 +210,73 @@ h1 {
   opacity: 0.6;
 }
 
+.converter-section {
+  margin-top: 40px;
+  padding-top: 30px;
+  border-top: 2px solid var(--border-color);
+}
+
+.converter-section h2 {
+  color: var(--text-primary);
+  font-size: 22px;
+  margin-bottom: 10px;
+}
+
+.converter-description {
+  color: var(--text-secondary);
+  font-size: 14px;
+  margin-bottom: 20px;
+}
+
+.convert-button,
+.download-button {
+  width: 100%;
+  padding: 16px;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  font-family: inherit;
+  margin-bottom: 10px;
+}
+
+.convert-button {
+  background: linear-gradient(135deg, #2e7d32 0%, #1b5e20 100%);
+  color: white;
+}
+
+.convert-button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 5px 20px rgba(46, 125, 50, 0.3);
+}
+
+.convert-button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.convert-button:disabled {
+  background: var(--border-color);
+  cursor: not-allowed;
+  transform: none;
+  opacity: 0.6;
+}
+
+.download-button {
+  background: linear-gradient(135deg, #ff6f00 0%, #e65100 100%);
+  color: white;
+}
+
+.download-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 5px 20px rgba(255, 111, 0, 0.3);
+}
+
+.download-button:active {
+  transform: translateY(0);
+}
+
 .loader {
   width: 40px;
   height: 40px;

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -45,6 +45,15 @@ export const translations = {
     language: {
       spanish: 'Español',
       english: 'English'
+    },
+    converter: {
+      title: '🔄 Convertir a PEM',
+      description: 'Combine su certificado .cer y llave .key en un solo archivo .pem',
+      convertButton: 'Convertir a PEM',
+      converting: 'Convirtiendo...',
+      downloadButton: 'Descargar archivo PEM',
+      success: '✅ Conversión exitosa! El archivo PEM está listo para descargar.',
+      includeChain: 'Incluir cadena de certificados completa'
     }
   },
   en: {
@@ -93,6 +102,15 @@ export const translations = {
     language: {
       spanish: 'Español',
       english: 'English'
+    },
+    converter: {
+      title: '🔄 Convert to PEM',
+      description: 'Combine your .cer certificate and .key key into a single .pem file',
+      convertButton: 'Convert to PEM',
+      converting: 'Converting...',
+      downloadButton: 'Download PEM file',
+      success: '✅ Conversion successful! PEM file is ready to download.',
+      includeChain: 'Include full certificate chain'
     }
   }
 };


### PR DESCRIPTION
## Descripción

Esta PR agrega funcionalidad para convertir pares de certificado (.cer) y llave privada (.key) a formato .pem combinado.

## Cambios

- ✨ Nueva sección de conversión a PEM en la UI
- 🔄 Función `convertToPEM()` que combina certificado y llave en un solo archivo
- 🔓 Descifrado automático de llaves privadas cifradas
- 📥 Botón de descarga para el archivo PEM generado
- 🌍 Traducciones completas en español e inglés
- 🎨 Estilos consistentes con el tema de la aplicación
- 🔒 Procesamiento 100% del lado del cliente (seguro)

## Funcionalidad

1. El usuario selecciona certificado (.cer) y llave (.key)
2. Ingresa la contraseña de la llave
3. Click en "Convertir a PEM"
4. Se genera un archivo .pem que combina ambos
5. Descarga el archivo mediante el botón "Descargar archivo PEM"

## Seguridad

- La llave privada se descifra en memoria
- El archivo PEM se genera completamente en el navegador
- Limpieza automática de datos sensibles después de la conversión
- Sin comunicación con servidores externos

## Testing

- [x] Probado con certificados .cer del Gobierno de Chihuahua
- [x] Probado con llaves PKCS#8 cifradas
- [x] Verificado en tema claro y oscuro
- [x] Verificado en español e inglés